### PR TITLE
Add platform indicator to widget

### DIFF
--- a/Munich-Commute-iOS-Widget-Scriptable.js
+++ b/Munich-Commute-iOS-Widget-Scriptable.js
@@ -513,7 +513,7 @@ async function createWidget() {
         rowStack.topAlignContent();
         
         // For medium and large sizes, add platform display on the right
-        if ((widgetSize === 'medium' || widgetSize === 'large') && departures[i].platform) {
+        if (widgetSize === 'medium' || widgetSize === 'large') {
             // Create platform badge on the right
             const platformContainer = rowStack.addStack();
             platformContainer.layoutVertically();
@@ -524,10 +524,13 @@ async function createWidget() {
             platformStack.backgroundColor = platformStack.backgroundColor.withAlpha(0.12); // 12% opacity
             platformStack.cornerRadius = 6; // Rounded square
             
-            const platformText = platformStack.addText(departures[i].platform.toString());
-            platformText.font = Font.boldSystemFont(10);
-            platformText.textColor = Color.white();
-            platformText.centerAlignText();
+            // Only add platform text if platform data exists
+            if (departures[i].platform) {
+                const platformText = platformStack.addText(departures[i].platform.toString());
+                platformText.font = Font.boldSystemFont(10);
+                platformText.textColor = Color.white();
+                platformText.centerAlignText();
+            }
             
             // Add spacing between platform and main content
             rowStack.addSpacer(8);


### PR DESCRIPTION
Add platform display to medium and large widget sizes, showing the platform number in a rounded square with 12% white opacity on the right.

---
<a href="https://cursor.com/background-agent?bcId=bc-56d491f2-ec59-443d-a411-f9df0402b131">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56d491f2-ec59-443d-a411-f9df0402b131">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

