### PR TITLE
Dim cancelled departures in widget

### DIFF
--- a/Munich Commute Widget.js
+++ b/Munich Commute Widget.js
@@ -87,6 +87,9 @@ const MAIN_MENU_ACTIONS = Object.freeze([
 
 // Fixed secondary departure font (for departures 2-6)
 const DEPARTURE_SECONDARY_FONT = Font.boldSystemFont(16);
+const CANCELLED_DEPARTURE_LINE_COLOR = "#6E6E6E";
+const CANCELLED_DEPARTURE_LINE_TEXT_OPACITY = 0.65;
+const CANCELLED_DEPARTURE_TIME_OPACITY = 0.45;
 
 // ============================================================================
 // WIDGET SIZE CONFIGURATION
@@ -317,6 +320,22 @@ function getLineColor(transportType, label) {
         return LINE_COLORS[transportType][label] || "#FFFFFF";
     }
     return LINE_COLORS[transportType] || "#FFFFFF";
+}
+
+function getDepartureVisualState(departure) {
+    if (departure && departure.cancelled === true) {
+        return {
+            lineBackgroundColor: CANCELLED_DEPARTURE_LINE_COLOR,
+            lineTextOpacity: CANCELLED_DEPARTURE_LINE_TEXT_OPACITY,
+            timeTextOpacity: CANCELLED_DEPARTURE_TIME_OPACITY
+        };
+    }
+
+    return {
+        lineBackgroundColor: null,
+        lineTextOpacity: 1,
+        timeTextOpacity: 1
+    };
 }
 
 // ============================================================================
@@ -702,6 +721,7 @@ async function createWidget() {
         console.log(`[DEBUG] lineStack.size set to: width=${widgetConfig.lineBadgeSize.width}, height=${widgetConfig.lineBadgeSize.height}`);
         lineStack.centerAlignContent();
 
+        const departureVisualState = getDepartureVisualState(departures[i]);
         const lineName = lineStack.addText(departures[i].label);
         const lineColor = getLineColor(departures[i].transportType, departures[i].label);
 
@@ -711,7 +731,11 @@ async function createWidget() {
         const gradTopKey = label + "_gradient_top";
         const gradBottomKey = label + "_gradient_bottom";
         let usedGradient = false;
-        if (transportColors && transportColors[gradTopKey] && transportColors[gradBottomKey]) {
+        if (departureVisualState.lineBackgroundColor) {
+            lineStack.backgroundColor = new Color(departureVisualState.lineBackgroundColor);
+            lineStack.cornerRadius = 4;
+            lineName.textColor = Color.white();
+        } else if (transportColors && transportColors[gradTopKey] && transportColors[gradBottomKey]) {
             const topColor = transportColors[gradTopKey];
             const bottomColor = transportColors[gradBottomKey];
             let grad = new LinearGradient();
@@ -736,6 +760,7 @@ async function createWidget() {
         }
 
         lineName.font = widgetConfig.lineBadgeFont;
+        lineName.textOpacity = departureVisualState.lineTextOpacity;
         lineName.centerAlignText();
         lineName.minimumScaleFactor = 0.4;
 
@@ -763,6 +788,7 @@ async function createWidget() {
             const plannedTimeStr = formatDepartureTime(plannedDate);
             const plannedTimeText = timeRowStack.addText(plannedTimeStr);
             plannedTimeText.textColor = Color.white();
+            plannedTimeText.textOpacity = departureVisualState.timeTextOpacity;
             plannedTimeText.font = i === 0 ? primaryDepartureFont : DEPARTURE_SECONDARY_FONT;
             plannedTimeText.lineLimit = 1;
 
@@ -771,7 +797,8 @@ async function createWidget() {
             const delayedDate = new Date(adjustedTime);
             const delayedMinutes = delayedDate.getMinutes().toString().padStart(2, '0');
             const colonMinutesText = timeRowStack.addText(':' + delayedMinutes);
-            colonMinutesText.textColor = new Color('#DB5C5C');
+            colonMinutesText.textColor = departures[i].cancelled ? Color.white() : new Color('#DB5C5C');
+            colonMinutesText.textOpacity = departureVisualState.timeTextOpacity;
             colonMinutesText.font = i === 0 ? primaryDepartureFont : DEPARTURE_SECONDARY_FONT;
             colonMinutesText.lineLimit = 1;
         } else {
@@ -781,6 +808,7 @@ async function createWidget() {
             timeRowStack.centerAlignContent();
             const mainTime = timeRowStack.addText(formatDepartureTime(adjustedTime));
             mainTime.textColor = Color.white();
+            mainTime.textOpacity = departureVisualState.timeTextOpacity;
             mainTime.font = i === 0 ? primaryDepartureFont : DEPARTURE_SECONDARY_FONT;
             mainTime.lineLimit = 1;
         }

--- a/Munich Commute Widget.js
+++ b/Munich Commute Widget.js
@@ -88,6 +88,7 @@ const MAIN_MENU_ACTIONS = Object.freeze([
 // Fixed secondary departure font (for departures 2-6)
 const DEPARTURE_SECONDARY_FONT = Font.boldSystemFont(16);
 const CANCELLED_DEPARTURE_LINE_COLOR = "#6E6E6E";
+const CANCELLED_DEPARTURE_LINE_BACKGROUND_OPACITY = 0.45;
 const CANCELLED_DEPARTURE_LINE_TEXT_OPACITY = 0.65;
 const CANCELLED_DEPARTURE_TIME_OPACITY = 0.45;
 
@@ -326,6 +327,7 @@ function getDepartureVisualState(departure) {
     if (departure && departure.cancelled === true) {
         return {
             lineBackgroundColor: CANCELLED_DEPARTURE_LINE_COLOR,
+            lineBackgroundOpacity: CANCELLED_DEPARTURE_LINE_BACKGROUND_OPACITY,
             lineTextOpacity: CANCELLED_DEPARTURE_LINE_TEXT_OPACITY,
             timeTextOpacity: CANCELLED_DEPARTURE_TIME_OPACITY
         };
@@ -333,6 +335,7 @@ function getDepartureVisualState(departure) {
 
     return {
         lineBackgroundColor: null,
+        lineBackgroundOpacity: 1,
         lineTextOpacity: 1,
         timeTextOpacity: 1
     };
@@ -732,9 +735,13 @@ async function createWidget() {
         const gradBottomKey = label + "_gradient_bottom";
         let usedGradient = false;
         if (departureVisualState.lineBackgroundColor) {
-            lineStack.backgroundColor = new Color(departureVisualState.lineBackgroundColor);
+            lineStack.backgroundColor = new Color(
+                departureVisualState.lineBackgroundColor,
+                departureVisualState.lineBackgroundOpacity
+            );
             lineStack.cornerRadius = 4;
             lineName.textColor = Color.white();
+            usedGradient = true;
         } else if (transportColors && transportColors[gradTopKey] && transportColors[gradBottomKey]) {
             const topColor = transportColors[gradTopKey];
             const bottomColor = transportColors[gradBottomKey];

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Works based on Scriptable app.
 - **Filtering** by transport types or platform
 - **All transport types** supported (S-Bahn, U-Bahn, Bus, Tram, Regional trains)
 - **Real-time departures** using official MVV API
-- **Cancelled departures** remain visible but appear dimmed, with a gray line badge
+- **Cancelled departures** remain visible but appear dimmed, with a translucent gray line badge
 - **Customizable colors**
 
 Color options:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Works based on Scriptable app.
 - **Filtering** by transport types or platform
 - **All transport types** supported (S-Bahn, U-Bahn, Bus, Tram, Regional trains)
 - **Real-time departures** using official MVV API
+- **Cancelled departures** remain visible but appear dimmed, with a gray line badge
 - **Customizable colors**
 
 Color options:
@@ -210,6 +211,7 @@ The script includes several customization options in the `CONFIG` object:
 
 This widget uses Munich's public transport API to fetch real-time departure data. The data includes:
 - Departure times with delay information
+- Cancellation status
 - Destination information
 - Line/route details
 - Transport type information

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -94,7 +94,7 @@ Status: ✅ done · ⚠️ partial / known nuance · ❌ not implemented
 
 - [ ] Cancelled departure row remains in the list
 - [ ] Departure time appears dimmed/gray on the gradient background
-- [ ] Line badge appears gray instead of active line color
+- [ ] Line badge appears translucent gray instead of active line color
 - [ ] No extra cancellation text is added, preserving widget space
 
 **Status:** ✅ Implemented via `getDepartureVisualState` and row rendering opacity/color.

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -88,6 +88,19 @@ Status: ✅ done · ⚠️ partial / known nuance · ❌ not implemented
 
 ---
 
+## 6a. Checking Cancelled Departures
+
+**Scenario:** the next matching departure is cancelled; it should remain visible so the user understands why the expected train is not active.
+
+- [ ] Cancelled departure row remains in the list
+- [ ] Departure time appears dimmed/gray on the gradient background
+- [ ] Line badge appears gray instead of active line color
+- [ ] No extra cancellation text is added, preserving widget space
+
+**Status:** ✅ Implemented via `getDepartureVisualState` and row rendering opacity/color.
+
+---
+
 ## 7. Editing an Existing Preset
 
 **Scenario:** changes station name, platform filter, or line filter without recreating the configuration from scratch.

--- a/ai-chat-history.md
+++ b/ai-chat-history.md
@@ -6,4 +6,4 @@
 - User reported cancelled S3 departures can appear active in the Munich commute widget.
 - Live MVG departure data includes `cancelled`, plus related fields such as `infos`, `messages`, `platformChanged`, `sev`, `realtime`, and `occupancy`.
 - Decision: keep cancelled departures visible because space is limited, but make them visually inactive by dimming the time and line badge/label with gray/opacity instead of adding text.
-- Implemented compact cancelled-departure styling: gray line badge, dimmed line text, and dimmed departure time. Added a regression test and documented the behavior.
+- Implemented compact cancelled-departure styling: translucent gray line badge, dimmed line text, and dimmed departure time. Added a regression test and documented the behavior.

--- a/ai-chat-history.md
+++ b/ai-chat-history.md
@@ -1,0 +1,9 @@
+# Task History
+
+## Cancelled train rendering
+
+### 2026-06-30
+- User reported cancelled S3 departures can appear active in the Munich commute widget.
+- Live MVG departure data includes `cancelled`, plus related fields such as `infos`, `messages`, `platformChanged`, `sev`, `realtime`, and `occupancy`.
+- Decision: keep cancelled departures visible because space is limited, but make them visually inactive by dimming the time and line badge/label with gray/opacity instead of adding text.
+- Implemented compact cancelled-departure styling: gray line badge, dimmed line text, and dimmed departure time. Added a regression test and documented the behavior.

--- a/tests/main-menu-actions.test.js
+++ b/tests/main-menu-actions.test.js
@@ -104,7 +104,8 @@ function loadWidgetExports() {
 globalThis.__testExports = {
     MAIN_MENU_ACTIONS,
     MAIN_MENU_ACTION,
-    getMainMenuActionForIndex
+    getMainMenuActionForIndex,
+    getDepartureVisualState
 };`, context, { filename: scriptPath });
 
     return context.__testExports;
@@ -126,4 +127,13 @@ test("main menu maps the visible Edit action to the edit action id", () => {
 
     assert.notEqual(editIndex, -1);
     assert.equal(getMainMenuActionForIndex(editIndex), MAIN_MENU_ACTION.EDIT_SAVED_STATION);
+});
+
+test("cancelled departures dim the time and use a gray line badge", () => {
+    const { getDepartureVisualState } = loadWidgetExports();
+    const state = getDepartureVisualState({ cancelled: true });
+
+    assert.equal(state.lineBackgroundColor, "#6E6E6E");
+    assert.equal(state.lineTextOpacity, 0.65);
+    assert.equal(state.timeTextOpacity, 0.45);
 });

--- a/tests/main-menu-actions.test.js
+++ b/tests/main-menu-actions.test.js
@@ -134,6 +134,7 @@ test("cancelled departures dim the time and use a gray line badge", () => {
     const state = getDepartureVisualState({ cancelled: true });
 
     assert.equal(state.lineBackgroundColor, "#6E6E6E");
+    assert.equal(state.lineBackgroundOpacity, 0.45);
     assert.equal(state.lineTextOpacity, 0.65);
     assert.equal(state.timeTextOpacity, 0.45);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep cancelled departures visible while making them visually inactive
- Apply a translucent gray line badge plus dimmed line/time opacity for `cancelled: true` API rows
- Document the compact cancellation behavior and add a regression test

## Verification
- `node --test`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d379dc40-7982-4517-8ee5-e3c42227fd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d379dc40-7982-4517-8ee5-e3c42227fd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

